### PR TITLE
Don't report when entries with multiple conditions and trailing comma

### DIFF
--- a/src/main/kotlin/com/doist/detekt/ConsistentWhenEntries.kt
+++ b/src/main/kotlin/com/doist/detekt/ConsistentWhenEntries.kt
@@ -33,5 +33,5 @@ class ConsistentWhenEntries(config: Config) : Rule(config) {
         }
     }
 
-    private fun KtWhenEntry.isMultiline() = text.count { it == '\n' } > 1
+    private fun KtWhenEntry.isMultiline() = (expression?.text?.count { it == '\n' } ?: 0) > 1
 }

--- a/src/test/kotlin/com/doist/detekt/ConsistentWhenEntriesTest.kt
+++ b/src/test/kotlin/com/doist/detekt/ConsistentWhenEntriesTest.kt
@@ -53,4 +53,38 @@ internal class ConsistentWhenEntriesTest(private val env: KotlinCoreEnvironment)
         val findings = rule.compileAndLintWithContext(env, code)
         findings shouldHaveSize 0
     }
+
+    @Test
+    fun `doesn't report single line when entries with multiple conditions and trailing comma`() {
+        val code = """
+            val a = listOf<Int>()
+            val b = when(a) {
+                is ArrayList,
+                is MutableList,
+                -> true
+                else -> false
+            }
+        """
+        val rule = ConsistentWhenEntries(Config.empty)
+        val findings = rule.compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
+
+    @Test
+    fun `report inconsistent when entries with multiple conditions and trailing comma`() {
+        val code = """
+            val a = listOf<Int>()
+            val b = when(a) {
+                is ArrayList,
+                is MutableList,
+                -> {
+                    true
+                }
+                else -> false
+            }
+        """
+        val rule = ConsistentWhenEntries(Config.empty)
+        val findings = rule.compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
 }


### PR DESCRIPTION
Update to `ConsistentWhenEntries` rule to allow when-blocks with multiple conditions in one when-entry with trailing commas.

Before, this was invalid but should be valid.
```kt
val a = listOf<Int>()
val b = when(a) {
    is ArrayList,
    is MutableList,
    -> true
    else -> false
}
```

Before, this was valid but should be invalid.

```kt
val a = listOf<Int>()
val b = when(a) {
    is ArrayList,
    is MutableList,
    -> {
        true
    }
    else -> false
}
```