### PR TITLE
Make releases purely tag based

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,27 +1,37 @@
 name: Publish package to GitHub Packages
 
 on:
-  release:
-    types: [ published ]
-  workflow_run:
-    workflows: [ Release ]
-    types: [ completed ]
+  push:
+    tags: [ v* ]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+
+      - name: Get version from tag
+        id: get_tag_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Publish package
-        run: ./gradlew publish
+        run: ./gradlew assemble publishAllPublicationsToGitHubPackagesRepository
         env:
+          VERSION: ${{ steps.get_tag_version.outputs.VERSION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}

--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ dependencies {
 
 ## Release
 
-To release, update the version in the `build.gradle.kts` file and run:
+To release, just push a tag with the new version number:
 ```
-git add build.gradle.kts
-git commit -m "Release X.Y.Z"
 git tag vX.Y.Z
 git push --tags
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.doist.detekt"
-version = "1.6.1"
+version = System.getenv("VERSION")
 
 repositories {
     mavenCentral()
@@ -32,6 +32,14 @@ tasks.withType<Test>().configureEach {
 }
 
 publishing {
+    publications {
+        register<MavenPublication>("gpr") {
+            artifactId = "detekt-rules"
+            groupId = group.toString()
+            version = project.version.toString()
+            from(components["java"])
+        }
+    }
     repositories {
         maven {
             name = "GitHubPackages"
@@ -40,11 +48,6 @@ publishing {
                 username = System.getenv("GITHUB_ACTOR")
                 password = System.getenv("GITHUB_TOKEN")
             }
-        }
-    }
-    publications {
-        register<MavenPublication>("gpr") {
-            from(components["java"])
         }
     }
 }


### PR DESCRIPTION
Right now, we need to merge a commit to main with the version update _and_ push a tag, which is not optimal, I think.
So this PR simplifies the release process to be strictly tag-push based, [similar](https://github.com/Doist/gradle-plugins/pull/221) to what I did sometime ago for gradle-plugins.